### PR TITLE
appending all user-written symbols

### DIFF
--- a/drcomplete-user-defined/info.rkt
+++ b/drcomplete-user-defined/info.rkt
@@ -1,6 +1,6 @@
 #lang info
 (define collection "drcomplete-user-defined")
-(define deps '("base" "drracket" "drracket-plugin-lib" "gui-lib"))
+(define deps '("base" "drracket" "drracket-plugin-lib" "gui-lib" "syntax-color-lib"))
 (define build-deps '("rackunit-lib"))
 (define pkg-desc "auto complete for user defined identifiers")
 (define version "0.1")

--- a/drcomplete-user-defined/tool.rkt
+++ b/drcomplete-user-defined/tool.rkt
@@ -1,7 +1,19 @@
 #lang racket
-(require drracket/tool racket/gui framework racket/runtime-path)
+(require drracket/tool racket/gui framework racket/runtime-path
+         syntax-color/module-lexer)
 (provide tool@)
 
+(define (symbols in)
+  (define s (set))
+  (let loop ([mode #f])
+    (define-values (str type _1 _2 _3 _4 new-mode)
+      (module-lexer in 0 mode))
+    (cond
+      [(eof-object? str) s]
+      [(eq? type 'symbol)
+       (set! s (set-add s str))
+       (loop new-mode)]
+      [else (loop new-mode)])))
 
 (define-runtime-path expansion.rkt "private/expansion.rkt")
 
@@ -26,6 +38,31 @@
           (append user-defined (super get-all-words)))
         ))
 
+    (define def-mixin
+      (mixin (racket:text<%> text:autocomplete<%>) ()
+        (inherit get-text)
+        (super-new)
+
+        (define/override (get-all-words)
+          (set->list
+           (set-union
+            (symbols (open-input-string (get-text)))
+            (list->set (super get-all-words)))))))
+
+    (define rep-mixin
+      (mixin (drracket:rep:text<%> text:autocomplete<%>) ()
+        (inherit get-definitions-text)
+        (super-new)
+
+        (define/override (get-all-words)
+          (define defs (get-definitions-text))
+          (if (is-a? defs drracket:unit:definitions-text<%>)
+              (set->list
+               (set-union
+                (symbols (open-input-string (send defs get-text)))
+                (list->set (super get-all-words))))
+              (super get-all-words)))))
+
     
     (drracket:module-language-tools:add-online-expansion-handler
      expansion.rkt 'go
@@ -36,6 +73,6 @@
                set-user-defined-identifiers v))))
 
     (define (phase1)
-      (drracket:get/extend:extend-interactions-text udc-mixin #f)
-      (drracket:get/extend:extend-definitions-text udc-mixin #f))
+      (drracket:get/extend:extend-interactions-text (compose rep-mixin udc-mixin) #f)
+      (drracket:get/extend:extend-definitions-text (compose def-mixin udc-mixin) #f))
     ))


### PR DESCRIPTION
When writing sth like
```
(define (func)
  <cursor>)
```
, the background expansion will fail and user-defined identifiers will not be updated until it becomes a valid program.
This solves the problem by appending all user-written symbols to candidates but it also introduces a few useless symbols.

May or may not remove repl support for this, since it use an undocumented method...