### PR TITLE
Refactoring drcomplete-required with syntax-bound-symbols

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         racket-variant: ['CS']
-        racket-version: ['8.0', 'current']
+        racket-version: ['8.0', '8.6', 'current']
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/drcomplete-required/private/expansion.rkt
+++ b/drcomplete-required/private/expansion.rkt
@@ -1,7 +1,11 @@
 #lang racket/base
 
-(require "walk.rkt" racket/set racket/exn)
+(require "utils.rkt" racket/set racket/exn)
 (provide go)
+(cond-use-bound
+ (require "walk-bound.rkt")
+ #:else
+ (require "walk.rkt"))
 (define (go v path src cust)
   (cond
     [(exn? v) #f]

--- a/drcomplete-required/private/utils.rkt
+++ b/drcomplete-required/private/utils.rkt
@@ -1,0 +1,24 @@
+#lang racket/base
+(require syntax/parse/define (for-syntax racket/base))
+
+(define-syntax-parser cond-bound
+  [(_ [(X:id ...) Body:expr ...] Rest ...)
+   (if (andmap identifier-binding (syntax->list #'(X ...)))
+       #'(begin Body ...)
+       (syntax/loc this-syntax (cond-bound Rest ...)))]
+  [(_  [(~literal else) Body:expr ...])
+   #'(begin Body ...)])
+
+(define-syntax-parse-rule (cond-use-bound Body:expr ... (~optional (~seq #:else Alt:expr ...) #:defaults ([(Alt 1) '()])))
+  (cond-bound
+   [(syntax-bound-phases syntax-bound-symbols)
+    Body ...]
+   [else Alt ...]))
+
+(define (visible? id)
+  (for/and ([scope (in-list
+                    (hash-ref (syntax-debug-info id)
+                              'context (λ () '())))])
+    (not (eq? 'macro (vector-ref scope 1)))))
+
+(provide (all-defined-out))

--- a/drcomplete-required/private/walk-bound.rkt
+++ b/drcomplete-required/private/walk-bound.rkt
@@ -1,0 +1,39 @@
+#lang racket/base
+(require racket/set racket/sequence syntax/kerncase "utils.rkt")
+
+(cond-use-bound
+ (define (walk form phase mods)
+   (kernel-syntax-case/phase
+    form phase
+    [(module ?id ?path (_ ?form ...))
+     (walk* #'(?form ...) 0 (cons #'?path mods))]
+    [(module* ?id ?f (_ ?form ...))
+     (eq? (syntax-e #'?f) #f)
+     (walk* #'(?form ...) phase (cons #'?f mods))]
+    [(module* ?id ?path (_ ?form ...))
+     (walk* #'(?form ...) 0 (cons #'?path mods))]
+    [(begin ?form ...)
+     (walk* #'(?form ...) phase mods)]
+    [(begin-for-syntax ?form ...)
+     (walk* #'(?form ...) (add1 phase) mods)]
+    [_ mods]))
+
+ (define (walk* form* phase mods)
+   (for/fold ([mods mods])
+             ([form (in-syntax form*)])
+     (walk form phase mods)))
+
+ (define (walk-module fpe)
+   (define mods
+     (kernel-syntax-case fpe #f
+       [(module ?id ?path (#%plain-module-begin ?form ...))
+        (walk* #'(?form ...) (namespace-base-phase) (list #'?path))]))
+   (define ids (mutable-set))
+   (for* ([mod (in-list mods)]
+          #:when (visible? mod)
+          [phase (in-list (syntax-bound-phases mod))]
+          [sym (in-list (syntax-bound-symbols mod phase))])
+     (set-add! ids sym))
+   ids)
+
+ (provide walk-module))

--- a/drcomplete-required/private/walk.rkt
+++ b/drcomplete-required/private/walk.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 (require racket/bool racket/set racket/sequence
-         (for-syntax racket/base) syntax/kerncase)
+         (for-syntax racket/base) syntax/kerncase
+         "utils.rkt")
 (provide walk-module)
 
 (define-syntax (for/union stx)
@@ -14,12 +15,6 @@
 
 (define (sym=? a b)
   (symbol=? (syntax-e a) (syntax-e b)))
-
-(define (visible? id)
-  (for/and ([scope (in-list
-                    (hash-ref (syntax-debug-info id)
-                              'context (λ () '())))])
-    (not (eq? 'macro (vector-ref scope 1)))))
 
 (define (walk-module fpe)
 

--- a/drcomplete-required/tests/test.rkt
+++ b/drcomplete-required/tests/test.rkt
@@ -40,6 +40,9 @@
                       (subset? (set 'id ...) imports)))
                    prologue))]))
 
+  (check-eq? (version<=? "8.6.0.8" (version))
+             (cond-use-bound #t #:else #f))
+
   (check-member '(module a racket/base)
                 call/cc)
 
@@ -174,6 +177,7 @@
                             #'(#%require (portal pid (1 2))))]))
                      (bind test))
                   test-portal))
+
   (cond-use-bound
     (check-member '(module a racket/base
                      (module b racket/base

--- a/drcomplete-required/tests/test.rkt
+++ b/drcomplete-required/tests/test.rkt
@@ -1,5 +1,9 @@
 #lang racket
-(require "../private/walk.rkt")
+(require "../private/utils.rkt")
+(cond-use-bound
+ (require "../private/walk-bound.rkt")
+ #:else
+ (require "../private/walk.rkt"))
 (module a racket/base
   (define ftest #f)
   (provide ftest))
@@ -134,28 +138,31 @@
                         (provide (for-label stx-pair?))))))
                 stx-pair?)
 
-  (when (version<=? "8.2.0.4" (version))
-    (check-member '(module a racket/base
-                     (#%require (just-space spaced "b.rkt")))
-                  #:not (asd)
-                  #:prologue
-                  (λ ()
-                    (parameterize ([current-module-declare-name
-                                    (make-resolved-module-path
-                                     (build-path (current-directory) "b.rkt"))])
-                      (eval
-                       '(module a racket/base
-                          (require (for-syntax racket/base))
-                          (provide (for-space spaced pri) asd)
+  (when (and (version<=? "8.2.0.4" (version)))
+    (cond-use-bound
+     (void)
+     #:else
+     (check-member '(module a racket/base
+                      (#%require (just-space spaced "b.rkt")))
+                   #:not (asd)
+                   #:prologue
+                   (λ ()
+                     (parameterize ([current-module-declare-name
+                                     (make-resolved-module-path
+                                      (build-path (current-directory) "b.rkt"))])
+                       (eval
+                        '(module a racket/base
+                           (require (for-syntax racket/base))
+                           (provide (for-space spaced pri) asd)
 
-                          (define-syntax spaced
-                            (λ (stx)
-                              (syntax-case stx ()
-                                [(_ form)
-                                 ((make-interned-syntax-introducer 'spaced) #'form)])))
-                          (spaced (define pri 2))
-                          (define asd 1)))))
-                  pri))
+                           (define-syntax spaced
+                             (λ (stx)
+                               (syntax-case stx ()
+                                 [(_ form)
+                                  ((make-interned-syntax-introducer 'spaced) #'form)])))
+                           (spaced (define pri 2))
+                           (define asd 1)))))
+                   pri)))
   (when (version<=? "8.3.0.8" (version))
     (check-member '(module a racket/base
                      (require (for-syntax racket/base racket/syntax))
@@ -167,4 +174,11 @@
                             #'(#%require (portal pid (1 2))))]))
                      (bind test))
                   test-portal))
+  (cond-use-bound
+    (check-member '(module a racket/base
+                     (module b racket/base
+                       (define fx 1)
+                       (provide (prefix-out b: fx)))
+                     (require 'b))
+                  b:fx))
   )


### PR DESCRIPTION
**Pros**
1. Much simpler and consistent implementation
2. Better at submodules defined within the same file

**Cons**
1. Ignores identifiers defined outside the default binding space
  This may not be a problem because the document says
```
By convention, when an identifier is bound in a space, a corresponding identifier also should be bound in the default binding space
```